### PR TITLE
Replacing qemu-user-static emulation with native cross compilation to speed up build time from 45 minutes to 7 minutes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -21,17 +21,17 @@ jobs:
       run: |
         if [ "$ARCH" == "armv7l" ]; then
             echo "PLATFORM=linux/arm/v7" >> $GITHUB_ENV
-            echo "ARCH_TUPLE=armv7-unknown-linux-gnueabihf" >> $GITHUB_ENV
+            echo "HOST_TRIPLE=armv7-unknown-linux-gnueabihf" >> $GITHUB_ENV
         elif [ "$ARCH" == "aarch64" ]; then
             echo "PLATFORM=linux/arm64" >> $GITHUB_ENV
-            echo "ARCH_TUPLE=aarch64-unknown-linux-gnu" >> $GITHUB_ENV
+            echo "HOST_TRIPLE=aarch64-unknown-linux-gnu" >> $GITHUB_ENV
         fi
     - name: Build the Docker image build environment
       run: |
         docker build --build-arg GECKODRIVER_VERSION=$GECKODRIVER_VERSION -t local/geckodriver-cross-builder .
     - name: Build the geckodriver binaries in the artifacts directory
       run: |    
-        docker run -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-cross-builder local/geckodriver-cross-builder bash -c "sh build-geckodriver-arm.sh release `echo $ARCH_TUPLE`"
+        docker run -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-cross-builder local/geckodriver-cross-builder bash -c "sh build-geckodriver-arm.sh release `echo $HOST_TRIPLE`"
     - name: Package up the binaries in a tar.gz and calculate md5 hashes
       run: |
         sudo chown -R runner:runner artifacts

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -46,17 +46,17 @@ jobs:
         echo "For details of what is contained in this release, see the [official geckodriver release notes](https://github.com/mozilla/geckodriver/releases)." >> release_notes.md
     - name: Upload artifacts with binaries and md5 hashes
       if: ${{ github.ref != 'refs/heads/master' }}
-      uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
           path: |
             geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
-      uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
           path: |
             geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
-      uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: release_notes.md
           path: |

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -47,16 +47,16 @@ jobs:
       if: ${{ github.ref != 'refs/heads/master' }}
       uses: actions/upload-artifact@v3
       with:
-        name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+        name: geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux-${{ env.ARCH }}.tar.gz
         path: |
-          geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+          geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux-${{ env.ARCH }}.tar.gz
     - name: Upload artifact md5
       if: ${{ github.ref != 'refs/heads/master' }}
       uses: actions/upload-artifact@v3
       with:
-        name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+        name: geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux-${{ env.ARCH }}.tar.gz.md5
         path: |
-          geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+          geckodriver-v${{ env.GECKODRIVER_VERSION }}-linux-${{ env.ARCH }}.tar.gz.md5
     - name: Upload artifact release_notes.md
       if: ${{ github.ref != 'refs/heads/master' }}
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -76,10 +76,10 @@ jobs:
         # Let faster job set the release notes
         if [ "$VERSION" != "v$GECKODRIVER_VERSION" ]; then
             echo "Set release notes"
-            #~/go/bin/github-release release -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name $RELEASE_TAG --description "`cat release_notes.md`"
+            ~/go/bin/github-release release -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name $RELEASE_TAG --description "`cat release_notes.md`"
             sleep 4
         fi
         echo "Upload files..."
-        #~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
-        #~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5 --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+        ~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+        ~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5 --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
         

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         arch: [armv7l, aarch64]
     env:
-      GECKODRIVER_VERSION: "0.31.0"
+      GECKODRIVER_VERSION: "0.32.0"
       ARCH: ${{ matrix.arch }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -31,7 +31,7 @@ jobs:
         docker build --build-arg GECKODRIVER_VERSION=$GECKODRIVER_VERSION -t local/geckodriver-cross-builder .
     - name: Build the geckodriver binaries in the artifacts directory
       run: |    
-        docker run -it -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-cross-builder local/geckodriver-cross-builder bash -c "sh build-geckodriver-arm.sh release `echo $ARCH_TUPLE`"
+        docker run -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-cross-builder local/geckodriver-cross-builder bash -c "sh build-geckodriver-arm.sh release `echo $ARCH_TUPLE`"
     - name: Package up the binaries in a tar.gz and calculate md5 hashes
       run: |
         sudo chown -R runner:runner artifacts

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, cross-compilation ]
   pull_request:
     branches: [ master ]
 
@@ -17,22 +17,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Initialize BuildKit and Register arm architectures
+    - name: Set environment variables
       run: |
-        docker buildx use `docker buildx create`
-        docker run --rm --privileged aptman/qus -- -r
-        docker run --rm --privileged aptman/qus -s -- -p
         if [ "$ARCH" == "armv7l" ]; then
             echo "PLATFORM=linux/arm/v7" >> $GITHUB_ENV
+            echo "ARCH_TUPLE=armv7-unknown-linux-gnueabihf" >> $GITHUB_ENV
         elif [ "$ARCH" == "aarch64" ]; then
             echo "PLATFORM=linux/arm64" >> $GITHUB_ENV
+            echo "ARCH_TUPLE=aarch64-unknown-linux-gnu" >> $GITHUB_ENV
         fi
     - name: Build the Docker image build environment
       run: |
-        docker buildx build --load --platform $PLATFORM --build-arg GECKODRIVER_VERSION=$GECKODRIVER_VERSION -t local/geckodriver-arm-builder .
+        docker build --build-arg GECKODRIVER_VERSION=$GECKODRIVER_VERSION -t local/geckodriver-cross-builder .
+        #docker buildx build --load --platform $PLATFORM --build-arg GECKODRIVER_VERSION=$GECKODRIVER_VERSION -t local/geckodriver-arm-builder .
     - name: Build the geckodriver binaries in the artifacts directory
-      run: |
-        docker run --rm --platform $PLATFORM -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-arm-builder local/geckodriver-arm-builder
+      run: |    
+        docker run -it -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-cross-builder local/geckodriver-cross-builder bash -c "sh build-geckodriver-arm.sh release `echo $ARCH_TUPLE`"
     - name: Package up the binaries in a tar.gz and calculate md5 hashes
       run: |
         sudo chown -R runner:runner artifacts
@@ -44,7 +44,25 @@ jobs:
         echo "NOTE:  This is an unofficial arm64 build and armhf of geckodriver v$GECKODRIVER_VERSION.  These binaries are compiled and built independently and are not provided by Mozilla." > release_notes.md  
         echo "" >> release_notes.md
         echo "For details of what is contained in this release, see the [official geckodriver release notes](https://github.com/mozilla/geckodriver/releases)." >> release_notes.md
+    - name: Upload artifacts with binaries and md5 hashes
+      if: ${{ github.ref != 'refs/heads/master' }}
+      uses: actions/upload-artifact@v3
+        with:
+          name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+          path: |
+            geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+      uses: actions/upload-artifact@v3
+        with:
+          name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+          path: |
+            geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+      uses: actions/upload-artifact@v3
+        with:
+          name: release_notes.md
+          path: |
+            release_notes.md
     - name: Publish releases with binaries and md5 hashes
+      if: ${{ github.ref == 'refs/heads/master' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -55,10 +73,10 @@ jobs:
         # Let faster job set the release notes
         if [ "$VERSION" != "v$GECKODRIVER_VERSION" ]; then
             echo "Set release notes"
-            ~/go/bin/github-release release -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name $RELEASE_TAG --description "`cat release_notes.md`"
+            #~/go/bin/github-release release -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name $RELEASE_TAG --description "`cat release_notes.md`"
             sleep 4
         fi
         echo "Upload files..."
-        ~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
-        ~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5 --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+        #~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+        #~/go/bin/github-release upload -u jamesmortensen -r geckodriver-arm-binaries --tag v$RELEASE_TAG --name geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5 --file geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
         

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -43,18 +43,22 @@ jobs:
         echo "NOTE:  This is an unofficial arm64 build and armhf of geckodriver v$GECKODRIVER_VERSION.  These binaries are compiled and built independently and are not provided by Mozilla." > release_notes.md  
         echo "" >> release_notes.md
         echo "For details of what is contained in this release, see the [official geckodriver release notes](https://github.com/mozilla/geckodriver/releases)." >> release_notes.md
-    - name: Upload artifacts with binaries and md5 hashes
+    - name: Upload artifact binary
       if: ${{ github.ref != 'refs/heads/master' }}
       uses: actions/upload-artifact@v3
       with:
         name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
         path: |
           geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+    - name: Upload artifact md5
+      if: ${{ github.ref != 'refs/heads/master' }}
       uses: actions/upload-artifact@v3
       with:
         name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
         path: |
           geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+    - name: Upload artifact release_notes.md
+      if: ${{ github.ref != 'refs/heads/master' }}
       uses: actions/upload-artifact@v3
       with:
         name: release_notes.md

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -29,7 +29,6 @@ jobs:
     - name: Build the Docker image build environment
       run: |
         docker build --build-arg GECKODRIVER_VERSION=$GECKODRIVER_VERSION -t local/geckodriver-cross-builder .
-        #docker buildx build --load --platform $PLATFORM --build-arg GECKODRIVER_VERSION=$GECKODRIVER_VERSION -t local/geckodriver-arm-builder .
     - name: Build the geckodriver binaries in the artifacts directory
       run: |    
         docker run -it -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-cross-builder local/geckodriver-cross-builder bash -c "sh build-geckodriver-arm.sh release `echo $ARCH_TUPLE`"
@@ -46,21 +45,21 @@ jobs:
         echo "For details of what is contained in this release, see the [official geckodriver release notes](https://github.com/mozilla/geckodriver/releases)." >> release_notes.md
     - name: Upload artifacts with binaries and md5 hashes
       if: ${{ github.ref != 'refs/heads/master' }}
-      - uses: actions/upload-artifact@v3
-        with:
-          name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
-          path: |
-            geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
-      - uses: actions/upload-artifact@v3
-        with:
-          name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
-          path: |
-            geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
-      - uses: actions/upload-artifact@v3
-        with:
-          name: release_notes.md
-          path: |
-            release_notes.md
+      uses: actions/upload-artifact@v3
+      with:
+        name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+        path: |
+          geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+        path: |
+          geckodriver-v$GECKODRIVER_VERSION-linux-$ARCH.tar.gz.md5
+      uses: actions/upload-artifact@v3
+      with:
+        name: release_notes.md
+        path: |
+          release_notes.md
     - name: Publish releases with binaries and md5 hashes
       if: ${{ github.ref == 'refs/heads/master' }}
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,19 @@ RUN echo "deb http://ftp.hk.debian.org/debian/ sid main" >> /etc/apt/sources.lis
   && apt-get autoremove && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* 
 
+RUN apt-get update -qqy \
+  && apt install -y gcc-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross \
+  && apt install -y gcc-aarch64-linux-gnu libc6-arm64-cross libc6-dev-arm64-cross \
+  && /root/.cargo/bin/rustup target install armv7-unknown-linux-gnueabihf \
+  && /root/.cargo/bin/rustup target install aarch64-unknown-linux-gnu \
+  && cd geckodriver \
+  && echo "[target.armv7-unknown-linux-gnueabihf]" >> .cargo/config \
+  && echo "linker = \"arm-linux-gnueabihf-gcc\"" >> .cargo/config \
+  && echo "[target.aarch64-unknown-linux-gnu]" >> .cargo/config \
+  && echo "linker = \"aarch64-linux-gnu-gcc\""  >> .cargo/config \
+  && apt-get autoremove && apt-get clean \
+  && rm -rf /var/lib/apt/list/* /var/cache/apt/*
+
 #===========
 # Copy build script to container
 #===========
@@ -31,4 +44,5 @@ COPY build-geckodriver-arm.sh /opt/geckodriver/
 #===========
 # Build geckodriver arm binary and copy to $PWD/artifacts
 #===========
+#RUN cd geckodriver && sh build-geckodriver-arm.sh
 CMD sh build-geckodriver-arm.sh

--- a/README.md
+++ b/README.md
@@ -58,8 +58,19 @@ Then build the geckodriver binary. Here's an example building geckodriver for ar
 docker run --rm -it --platform linux/arm/v7 -v $PWD/artifacts:/media/host -w /opt/geckodriver --name geckodriver-arm-builder local/geckodriver-arm-builder
 ```
 
+## Building with cross-compilation
 
-### Additional information
+It's also possible to build a geckodriver binary on one host architecture that targets another architecture. This information is adapted from Mozilla's developer documentation on [Self Serving an ARM build](https://firefox-source-docs.mozilla.org/testing/geckodriver/ARM.html).
+
+### armv7l/armhf
+
+
+### aarch64/arm64
+
+
+
+
+## Additional information
 
 The binary is copied to $PWD/artifacts.  If you're using podman-machine or running Docker in a VM, then you'll need to copy the binary from Podman or the VM via scp or by mounting a shared volume.
 

--- a/build-geckodriver-arm.sh
+++ b/build-geckodriver-arm.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
-TARGET=${1:-release}
+TYPE=${1:-release}
+ARCH_TUPLE=$2
 
-if [ "$TARGET" = "release" ]; then
-    cargo build --release
-else
-    cargo build
+# Pass as 2nd argument: aarch64-unknown-linux-gnu or armv7-unknown-linux-gnueabihf
+# else if blank then build for host architecture
+if [ -n "$ARCH_TUPLE" ]; then
+    TARGET="--target $ARCH_TUPLE"
+    . $HOME/.cargo/env
+    rustup target add $ARCH_TUPLE
 fi
 
-cp /opt/geckodriver/target/$TARGET/geckodriver /media/host
+if [ "$TYPE" = "release" ]; then
+    cargo build --release $TARGET
+else
+    cargo build $TARGET
+fi
+
+if [ -z "$ARCH_TUPLE" ]; then
+    cp /opt/geckodriver/target/$TYPE/geckodriver /media/host
+else
+    cp /opt/geckodriver/target/$ARCH_TUPLE/$TYPE/geckodriver /media/host
+fi

--- a/build-geckodriver-arm.sh
+++ b/build-geckodriver-arm.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 TYPE=${1:-release}
-ARCH_TUPLE=$2
+HOST_TRIPLE=$2
 
 # Pass as 2nd argument: aarch64-unknown-linux-gnu or armv7-unknown-linux-gnueabihf
 # else if blank then build for host architecture
-if [ -n "$ARCH_TUPLE" ]; then
-    TARGET="--target $ARCH_TUPLE"
+if [ -n "$HOST_TRIPLE" ]; then
+    TARGET="--target $HOST_TRIPLE"
     . $HOME/.cargo/env
-    rustup target add $ARCH_TUPLE
+    rustup target add $HOST_TRIPLE
 fi
 
 if [ "$TYPE" = "release" ]; then
@@ -16,8 +16,8 @@ else
     cargo build $TARGET
 fi
 
-if [ -z "$ARCH_TUPLE" ]; then
+if [ -z "$HOST_TRIPLE" ]; then
     cp /opt/geckodriver/target/$TYPE/geckodriver /media/host
 else
-    cp /opt/geckodriver/target/$ARCH_TUPLE/$TYPE/geckodriver /media/host
+    cp /opt/geckodriver/target/$HOST_TRIPLE/$TYPE/geckodriver /media/host
 fi


### PR DESCRIPTION
QEMU emulation can be slow because it involves software translation from one architecture to another.  Instead, many compilers offer the ability to build for other architectures without having to actually compile _on_ that platform.  Currently, geckodriver arm64 and armhf are built on an x86_64 GitHub Actions runner, using QEMU user emulation to emulate arm in a container, along with BuildKit, to build on emulated arm64 and armhf architectures.  A 45 minute build time is the result.

Using native cross-compilation, where we run the build process in a native x86_64 container, but pass a compiler flag with instructions to build for arm64 or armhf, a 6 minute build time is the result.